### PR TITLE
move display slide down with @media max-width

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -20,3 +20,28 @@
     }
   }
 }
+
+@media(max-width: 360px) {
+  #tag-form {
+    position: relative;
+    a {
+      i {
+        color: $bittersweet;
+        position: absolute;
+        font-size: 24px;
+        left: .1em;
+        top: 30%;
+      }
+    }
+
+    div {
+      margin: auto;
+      input {
+        margin: 8px;
+      }
+      input[type=submit] {
+        border: none;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/pages/_review_show.scss
+++ b/app/assets/stylesheets/pages/_review_show.scss
@@ -2,7 +2,7 @@
   border: none;
 }
 
-.hold-here {
+.hold-here-rev {
   position: relative;
   top: -105px;
   z-index: 2;
@@ -13,5 +13,13 @@
     a {
       color: $verdigris;
     }
+  }
+}
+
+@media(max-width: 360px) {
+  .hold-here-rev {
+    position: relative;
+    top: -85px;
+    z-index: 2;
   }
 }

--- a/app/assets/stylesheets/pages/_venue_show.scss
+++ b/app/assets/stylesheets/pages/_venue_show.scss
@@ -86,3 +86,11 @@
   display: none;
 }
 
+@media(max-width: 360px) {
+  .hold-here {
+    position: relative;
+    top: -75px;
+    z-index: 2;
+  }
+}
+

--- a/app/javascript/components/init_venue_show.js
+++ b/app/javascript/components/init_venue_show.js
@@ -24,12 +24,10 @@ const toggleDisplay = () => {
 
 const showAddTagForm = () => {
 
-  // check to make sure the right elements are being selected!!
-  // const addBtn = document.getElementById('add-new');
   const tagBtn = document.getElementById('tag-btn');
   const formBox = document.getElementById('form-box');
   const form = document.querySelector('.form-inline');
-  const offToggle = document.querySelector("#tag-form > a");
+  const offToggle = document.querySelector("#tag-form > .form-inline > a");
 
   if(tagBtn) {
 

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="hold-here">
+  <div class="hold-here-rev">
     <div class="d-flex justify-content-center w-100 mt-2 mb-3">
       <% if @review.user.photo.attached? %>
         <%= cl_image_tag @review.user.photo.key, width: 200, height: 200, crop: :fill, class: "avatar-bordered" %>

--- a/app/views/venuetags/_form.html.erb
+++ b/app/views/venuetags/_form.html.erb
@@ -1,8 +1,8 @@
 <%= simple_form_for [@venue, @venuetag], remote: true, html: { class: 'form-inline', id: 'tag-form' } do |f| %>
-  <%= link_to 'javascript:;', id: 'off-toggle' do %>
-    <i class="far fa-window-close"></i>
-  <% end %>
   <div class='form-inline'>
+    <%= link_to 'javascript:;', id: 'off-toggle' do %>
+      <i class="far fa-window-close"></i>
+    <% end %>
     <%= f.association :tag, collection: Tag.order('name ASC'), label: false %>
     <%= f.submit "ADD", class: 'btn-lp'%>
   </div>


### PR DESCRIPTION
![Screen Shot 2021-03-07 at 12 29 21 PM](https://user-images.githubusercontent.com/48184114/110238949-a9e82880-7f44-11eb-9ea3-224bdccbf4fb.png)
when the selected device is Moto G4 or Galaxy the negative display affect is similar to that which I've experienced on my phone.  So, using these settings I implemented an @media(max-width: 360px) to slide the content of these pages conditionally.  While there are some differences, in positioning, everything is visible now.


![Screen Shot 2021-03-07 at 12 36 21 PM](https://user-images.githubusercontent.com/48184114/110239020-14996400-7f45-11eb-89a3-0899c84263fc.png)
test by fetching and rails s-in'

NOTE: we should definitely do more testing after deploying, but I think this give a good guideline.
