### PR TITLE
Change text links to icons

### DIFF
--- a/app/views/shared/_navbar_basic.html.erb
+++ b/app/views/shared/_navbar_basic.html.erb
@@ -16,9 +16,9 @@
     </div>
     <div class="right flex">
       <% if user_signed_in? %>
-          <%= link_to "Log out", destroy_user_session_path, class: "link", method: :delete %>
+          <%= link_to raw('<i class="fas fa-sign-out-alt"></i>'), destroy_user_session_path, method: :delete %>
       <% else %>
-          <%= link_to "Login", new_user_session_path, class: "link" %>
+          <%= link_to raw('<i class="fas fa-sign-in-alt"></i>'), new_user_session_path %>
       <% end %>
     </div>
   </div>

--- a/app/views/shared/_navbar_basic.html.erb
+++ b/app/views/shared/_navbar_basic.html.erb
@@ -1,7 +1,7 @@
 <div class="navbar navbar-lewagon venue-review-show">
   <div class= "d-flex align-items-center w-100 mt-2 mb-3">
     <div class="left flex">
-      <%= link_to 'To Map', venues_path, class: "link" %>
+      <%= link_to raw('<i class="fas fa-map-marked-alt"></i>'), venues_path %>
     </div>
     <div class="center flex">
       <h2>

--- a/app/views/shared/_navbar_index.html.erb
+++ b/app/views/shared/_navbar_index.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar navbar-lewagon">
   <div class= "d-flex align-items-center w-100 mt-2 mb-3">
-    <%= link_to raw('<i class="fas fa-home"></i>'), root_path %>
+    <%= link_to raw('<i class="fas fa-home"></i>'), root_path, class: "left flex" %>
     <h2 class="center flex">Venues</h2>
     <div class="right flex">
       <% if user_signed_in? %>

--- a/app/views/shared/_navbar_index.html.erb
+++ b/app/views/shared/_navbar_index.html.erb
@@ -1,12 +1,12 @@
 <div class="navbar navbar-lewagon">
   <div class= "d-flex align-items-center w-100 mt-2 mb-3">
-    <%= link_to 'Back', :back, class: "link left flex" %>
+    <%= link_to raw('<i class="fas fa-home"></i>'), root_path %>
     <h2 class="center flex">Venues</h2>
     <div class="right flex">
       <% if user_signed_in? %>
-          <%= link_to "Log out", destroy_user_session_path, method: :delete %>
+          <%= link_to raw('<i class="fas fa-sign-out-alt"></i>'), destroy_user_session_path, method: :delete %>
       <% else %>
-          <%= link_to "Login", new_user_session_path, class: "nav-link" %>
+          <%= link_to raw('<i class="fas fa-sign-in-alt"></i>'), new_user_session_path %>
       <% end %>
     </div>
    </div>

--- a/app/views/shared/_navbar_root.html.erb
+++ b/app/views/shared/_navbar_root.html.erb
@@ -1,9 +1,9 @@
 <div class="navbar navbar-lewagon">
   <div class="d-flex justify-content-end w-100">
     <% if user_signed_in? %>
-        <%= link_to "Log out", destroy_user_session_path, class: "nav-link pb-0", method: :delete %>
-    <% else %>
-        <%= link_to "Login", new_user_session_path, class: "nav-link pb-0" %>
+        <%= link_to raw('<i class="fas fa-sign-out-alt"></i>'), destroy_user_session_path, method: :delete %>
+      <% else %>
+          <%= link_to raw('<i class="fas fa-sign-in-alt"></i>'), new_user_session_path %>
     <% end %>
    </div>
   <div class="w-100">

--- a/app/views/shared/_navbar_root.html.erb
+++ b/app/views/shared/_navbar_root.html.erb
@@ -1,9 +1,9 @@
 <div class="navbar navbar-lewagon">
   <div class="d-flex justify-content-end w-100">
     <% if user_signed_in? %>
-        <%= link_to raw('<i class="fas fa-sign-out-alt"></i>'), destroy_user_session_path, method: :delete %>
+        <%= link_to raw('<i class="fas fa-sign-out-alt"></i>'), destroy_user_session_path, method: :delete, class: "nav-link pb-0" %>
       <% else %>
-          <%= link_to raw('<i class="fas fa-sign-in-alt"></i>'), new_user_session_path %>
+          <%= link_to raw('<i class="fas fa-sign-in-alt"></i>'), new_user_session_path, class: "nav-link pb-0" %>
     <% end %>
    </div>
   <div class="w-100">


### PR DESCRIPTION
What I did:
1. Change login/logout links on all pages (including root) to icons and To Map link to icons on show pages:
<img width="301" alt="Screen Shot 2021-03-10 at 10 43 18" src="https://user-images.githubusercontent.com/57105267/110611983-0b500780-8190-11eb-8692-887935991536.png">
<img width="301" alt="Screen Shot 2021-03-10 at 10 44 44" src="https://user-images.githubusercontent.com/57105267/110611484-8d8bfc00-818f-11eb-816c-f3d215a62e8d.png">
2. Change back link on index page to home icon (note the issue with poor positioning of Venues text, see change 3 for correction):
<img width="301" alt="Screen Shot 2021-03-10 at 10 43 32" src="https://user-images.githubusercontent.com/57105267/110612319-5cf89200-8190-11eb-976b-5ccaf0e1f362.png">
3. add class left flex to home link to resolve the above issue regarding Venue text position. Now centered properly:
<img width="301" alt="Screen Shot 2021-03-10 at 10 44 20" src="https://user-images.githubusercontent.com/57105267/110612982-017ad400-8191-11eb-9946-84e0784bf4c5.png">

How to test:
fetch branch and test locally with rails server on localhost