### PR TITLE
add ability to upload multiple photos at once when creating new venue

### DIFF
--- a/app/controllers/venues_controller.rb
+++ b/app/controllers/venues_controller.rb
@@ -53,6 +53,6 @@ class VenuesController < ApplicationController
   end
 
   def venue_params
-    params.require(:venue).permit(:name, :address, :category, :description, :photos)
+    params.require(:venue).permit(:name, :address, :category, :description, photos: [])
   end
 end

--- a/app/views/venues/new.html.erb
+++ b/app/views/venues/new.html.erb
@@ -4,7 +4,7 @@
     <%= f.input :name %>
     <%= f.input :description %>
     <%= f.input :address %>
-    <%= f.input :photos, as: :file %>
+    <%= f.input :photos, as: :file, input_html: { multiple: true } %>
     <%= f.input :category, collection: Venue::CATEGORIES %>
     <%= f.button :submit, 'SAVE', class: 'btn-block btn-lp' %>
   <% end %>


### PR DESCRIPTION
![Screen Shot 2021-03-10 at 10 33 35 PM](https://user-images.githubusercontent.com/48184114/110700807-ad074100-81f0-11eb-8815-1016c3fa9468.png)

In setting up our demo venue I noticed while we planned on it, we couldn't technically add multiple photos at once when creating the venue.  it just took a couple characters in the controller and a `input_html: { multiple: true }` in the form field.

I tested in development with the pics I chose to use for the demo venue. We'll need to push this to heroku before tomorrows demo (if its appropriate to merge) :D

test with a fetch-n-rails s