### PR TITLE
add photo input on form, add :photo as attribute to be sanitized in A…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    attributes = [:dog_name, :owner_name, :email]
+    attributes = [:dog_name, :owner_name, :photo, :email]
     devise_parameter_sanitizer.permit(:sign_up, keys: attributes)
     devise_parameter_sanitizer.permit(:account_update, keys: attributes)
   end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -18,6 +18,7 @@
   <div class="form-inputs">
     <%= f.input :dog_name %>
     <%= f.input :owner_name %>
+    <%= f.input :photo, as: :file %>
     <%= f.input :email,
                 required: true,
                 autofocus: true,


### PR DESCRIPTION
similar to the multiple photos added to the venue, I noticed I couldn't add a photo when creating a User - I think we planned to do this in the User#edit view, but we didn't get to it... SO I added the form and managed it in the AppController.  

Again - I just needed a custom photo for Albi's user profile so we have a review to look at in the demo that has a matching User pic and review pic

T.B.F.A.R.S. (test by fetch and rails s)